### PR TITLE
feat: 棒読みちゃん送信メッセージのログ保存機能を追加（resources/message_log.txt） #23

### DIFF
--- a/src/services/bouyomi_client.py
+++ b/src/services/bouyomi_client.py
@@ -8,6 +8,7 @@ import socket
 import struct
 import time
 from typing import Dict, Optional, Tuple
+from src.utils.message_log import save_message_log
 
 class BouyomiClient:
     """棒読みちゃんクライアントクラス。
@@ -83,6 +84,7 @@ class BouyomiClient:
                 if result:
                     if attempt > 1:
                         self.logger.info(f"リトライ{attempt-1}回目で復旧成功: {text}")
+                    save_message_log(text)
                     return True
                 else:
                     raise ConnectionError("送信失敗")
@@ -126,6 +128,7 @@ class BouyomiClient:
                     self.logger.debug(f"送信バイト列: {packet}")
                     sock.sendall(packet)
                 self.logger.info(f"棒読みちゃん本体にバイナリコマンド送信: {text}")
+                save_message_log(text)
                 if attempt > 1:
                     self.logger.info(f"リトライ{attempt-1}回目で復旧成功: {text}")
                 return True

--- a/src/utils/message_log.py
+++ b/src/utils/message_log.py
@@ -1,0 +1,24 @@
+"""
+棒読みちゃん送信メッセージのログ保存ユーティリティ。
+"""
+import os
+from pathlib import Path
+import logging
+from datetime import datetime
+
+LOG_FILE_PATH = Path(__file__).parent.parent / "resources" / "message_log.txt"
+
+
+def save_message_log(message: str) -> None:
+    """
+    メッセージ送信ログをファイルに追記保存します。
+    Args:
+        message: 送信したテキスト
+    """
+    try:
+        LOG_FILE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with open(LOG_FILE_PATH, "a", encoding="utf-8") as f:
+            timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            f.write(f"{timestamp} {message}\n")
+    except Exception as e:
+        logging.getLogger(__name__).error(f"メッセージログ保存エラー: {e}", exc_info=True) 


### PR DESCRIPTION
- 棒読みちゃんに送信したメッセージを `resources/message_log.txt` に日時付きで保存する機能を追加しました。
- 送信成功時のみ記録され、エラー時はロギングされます。
- PEP8/PEP257/型アノテーション/ロギング/エラーハンドリングに準拠しています。

ご確認の上、マージをお願いします。