### PR TITLE
exeファイルにリソースフォルダの音声ファイルを組み込む

### DIFF
--- a/.github/workflows/release-exe.yml
+++ b/.github/workflows/release-exe.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: EXEビルド
         run: |
-          pyinstaller --noconfirm --onefile --windowed --name WindowCaptureReading --add-data "src;src" src/gui_main.py --distpath dist
+          pyinstaller --noconfirm --onefile --windowed --name WindowCaptureReading --add-data "src;src" --add-data "resources;resources" src/gui_main.py --distpath dist
 
       - name: リリース作成とEXEファイルアップロード
         uses: softprops/action-gh-release@v2

--- a/build_exe.ps1
+++ b/build_exe.ps1
@@ -10,6 +10,6 @@ pip install -r requirements.txt
 pip install pyinstaller
 
 # exeビルド
-pyinstaller --noconfirm --onefile --windowed --name WindowCaptureReading --add-data "src;src" src/gui_main.py --distpath dist
+pyinstaller --noconfirm --onefile --windowed --name WindowCaptureReading --add-data "src;src" --add-data "resources;resources" src/gui_main.py --distpath dist
 
 Write-Host "ビルド完了: dist/WindowCaptureReading.exe" 

--- a/src/gui_main.py
+++ b/src/gui_main.py
@@ -23,6 +23,7 @@ import sys
 import datetime
 from src.utils.config import Config, get_config
 from src.services.difference_detector import DifferenceDetector
+from src.utils.resource_path import get_sound_file_path
 
 # グローバル変数の初期化
 roi = None  # ROI矩形座標 [x1, y1, x2, y2]
@@ -32,26 +33,6 @@ detector = None  # 差分検知器
 
 # 省略表示用関数を追加
 MAX_TITLE_DISPLAY_LENGTH = 24  # 表示上限（全角換算で調整可）
-
-# 通知音ファイルのパスを取得する関数
-def get_sound_file_path() -> str:
-    """
-    通知音ファイルのパスを返す。exe化された場合とそうでない場合に対応。
-    
-    Returns:
-        str: 通知音ファイルのパス
-    """
-    # exe化されている場合
-    if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
-        base_dir = sys._MEIPASS
-    else:
-        # 通常実行の場合
-        base_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
-    
-    # 通知音ファイルのパス
-    sound_path = os.path.join(base_dir, 'resources', 'notification_sound.wav')
-    
-    return sound_path
 
 # 音声を再生する関数
 def play_notification_sound() -> bool:

--- a/src/resource_path.py
+++ b/src/resource_path.py
@@ -1,0 +1,34 @@
+import os
+import sys
+from typing import Optional
+
+
+def get_resource_path(relative_path: str) -> str:
+    """
+    リソースファイルのパスを取得する。
+    PyInstallerでパッケージ化された場合と通常実行の場合の両方に対応する。
+
+    Args:
+        relative_path: リソースファイルの相対パス
+
+    Returns:
+        str: リソースファイルの絶対パス
+    """
+    # exe化されている場合
+    if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
+        base_dir = sys._MEIPASS
+    else:
+        # 通常実行の場合
+        base_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+    
+    return os.path.join(base_dir, relative_path)
+
+
+def get_sound_file_path() -> str:
+    """
+    通知音ファイルのパスを取得する。
+
+    Returns:
+        str: 通知音ファイルのパス
+    """
+    return get_resource_path(os.path.join('resources', 'notification_sound.wav'))

--- a/src/utils/resource_path.py
+++ b/src/utils/resource_path.py
@@ -1,0 +1,34 @@
+import os
+import sys
+from typing import Optional
+
+
+def get_resource_path(relative_path: str) -> str:
+    """
+    リソースファイルのパスを取得する。
+    PyInstallerでパッケージ化された場合と通常実行の場合の両方に対応する。
+
+    Args:
+        relative_path: リソースファイルの相対パス
+
+    Returns:
+        str: リソースファイルの絶対パス
+    """
+    # exe化されている場合
+    if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
+        base_dir = sys._MEIPASS
+    else:
+        # 通常実行の場合
+        base_dir = os.path.abspath(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+    
+    return os.path.join(base_dir, relative_path)
+
+
+def get_sound_file_path() -> str:
+    """
+    通知音ファイルのパスを取得する。
+
+    Returns:
+        str: 通知音ファイルのパス
+    """
+    return get_resource_path(os.path.join('resources', 'notification_sound.wav')) 


### PR DESCRIPTION
## 概要
Issue #54 の対応として、PyInstallerでexeファイルをビルドする際に、resourcesフォルダの音声ファイルも含まれるように修正しました。

## 変更内容
1. `build_exe.ps1`の`pyinstaller`コマンドに`--add-data "resources;resources"`オプションを追加
2. リソースパスを効率的に扱うための`resource_path.py`ユーティリティモジュールを追加
3. `gui_main.py`の重複するパス取得関数を削除し、新しいユーティリティモジュールを使用するよう修正

## テスト
- exeファイルをビルドして通知音が正常に再生されることを確認済み

## 関連Issue
Closes #54