### PR TITLE
fix: ログファイルが設定に関わらず出力される問題を修正

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -20,7 +20,6 @@ import ctypes
 from ctypes import windll
 
 from src.main import run_main_loop
-from src.utils.logging_config import setup_logging
 from src.utils.config import Config, get_config
 from src.services.window_capture import WindowCapture
 from src.services.difference_detector import DifferenceDetector
@@ -48,7 +47,6 @@ class MainWindow:
             self.logger.warning(f"DPIスケーリング設定に失敗しました: {e}")
 
         # ロガーのセットアップ
-        setup_logging()
         self.logger: logging.Logger = logging.getLogger(__name__)
 
         # ウィンドウの設定

--- a/src/main.py
+++ b/src/main.py
@@ -12,7 +12,7 @@ from src.types import ImageArray
 from src.services.window_capture import WindowCapture
 from src.services.difference_detector import DifferenceDetector
 from src.utils.config import get_config
-from src.utils.logging_config import setup_logging, reconfigure_logging
+from src.utils.logging_config import reconfigure_logging
 
 
 def run_main_loop(
@@ -88,10 +88,7 @@ def run_main_loop(
 
 def main() -> None:
     """アプリケーションのエントリーポイント。"""
-    # ロギングの初期設定
-    setup_logging()
-
-    # 設定を読み込み、ログ設定を再構成
+    # 設定を読み込み、ログ設定を構成
     config = get_config()
     reconfigure_logging(config)
 

--- a/src/utils/logging_config.py
+++ b/src/utils/logging_config.py
@@ -39,7 +39,10 @@ def setup_logging() -> None:
 
 def reconfigure_logging(config: "Config") -> None:
     """
-    設定に基づいてロギング設定を再構成する。
+    設定に基づいてロギング設定を構成する。
+
+    アプリケーション起動時に最初に呼び出されます。
+    既存のハンドラがあれば削除し、設定に基づいて新しいハンドラを追加します。
 
     Args:
         config: 設定オブジェクト


### PR DESCRIPTION
## 問題
PR #61 でログ設定機能を追加しましたが、`setup_logging()`が常にFileHandlerを追加していたため、「ログファイルを出力する」をオフにしてもapp.logが作成される問題がありました。

## 修正内容
- `src/main.py`と`src/gui/main_window.py`から`setup_logging()`の呼び出しを削除
- アプリケーション起動時は`reconfigure_logging(config)`のみを使用
- `reconfigure_logging()`が設定に基づいてログを制御するように変更

## 動作
これにより、`enable_log_file=False`（デフォルト）の場合、app.logは一切出力されなくなります。

## テスト確認
- [x] 開発環境で`python -m src.main`を実行し、app.logが出力されないことを確認
- [x] 設定画面で「ログファイルを出力する」をオンにして、app.logが生成されることを確認
- [x] 設定画面で「ログファイルを出力する」をオフにして、app.logが生成されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)